### PR TITLE
add signAmino

### DIFF
--- a/wallets/terra-extension/package.json
+++ b/wallets/terra-extension/package.json
@@ -92,7 +92,7 @@
     "@babel/runtime": "7.11.2",
     "@chain-registry/types": "0.13.1",
     "@cosmos-kit/core": "^1.0.4",
-    "@terra-money/feather.js": "^1.0.0-beta.12",
+    "@terra-money/feather.js": "^1.0.0-beta.14",
     "@terra-money/wallet-types": "^3.11.2",
     "react-icons": "4.4.0",
     "snake-case": "^3.0.4"

--- a/wallets/terra-extension/src/extension/client.ts
+++ b/wallets/terra-extension/src/extension/client.ts
@@ -1,7 +1,4 @@
 import { WalletClient, WalletAccount } from '@cosmos-kit/core';
-import { LCDClient } from '@terra-money/feather.js';
-import { decodePubkey } from '@cosmjs/proto-signing';
-import { BaseAccount as BaseAccount_pb } from '@terra-money/terra.proto/cosmos/auth/v1beta1/auth';
 import { TerraExtension } from './extension';
 import { OfflineSigner } from './signer';
 import { fromBase64 } from '@cosmjs/encoding';
@@ -28,7 +25,6 @@ export class TerraClient implements WalletClient {
     }
 
     const account = await this.client.connect();
-
     const info = (await this.client.info())[chainId];
 
     if (!info || info.chainID !== chainId) {
@@ -37,33 +33,9 @@ export class TerraClient implements WalletClient {
       );
     }
 
-    const lcd = LCDClient.fromDefaultConfig(
-      chainId === 'phoenix-1' ? 'mainnet' : 'testnet'
-    );
-
-    // HACK: doesn't use when signing process
-    let pubkey = fromBase64('ApK7dnTXNvycFDkLcNbFy9fi1OMnfjHMLWP+pWoulwoh');
+    // For now, Station Wallet only supports cointype 330
+    let pubkey = fromBase64(account.pubkey[330]);
     let algo: 'secp256k1' | 'ed25519' | 'sr25519' = 'secp256k1';
-
-    try {
-      const accountInfo = (
-        await lcd.auth.accountInfo(account.address)
-      ).toProto() as BaseAccount_pb;
-
-      if (accountInfo?.pubKey?.typeUrl.match(/secp256k1/i)) {
-        algo = 'secp256k1';
-      } else if (accountInfo?.pubKey?.typeUrl.match(/ed25519/i)) {
-        algo = 'ed25519';
-      } else if (accountInfo?.pubKey?.typeUrl.match(/sr25519/i)) {
-        algo = 'sr25519';
-      }
-
-      if (accountInfo.pubKey) {
-        pubkey = fromBase64(decodePubkey(accountInfo.pubKey).value);
-      }
-    } catch (err) {
-      console.log(err);
-    }
 
     return {
       name: 'Station Wallet',

--- a/wallets/terra-extension/src/extension/extension.ts
+++ b/wallets/terra-extension/src/extension/extension.ts
@@ -1,7 +1,7 @@
 import { Extension, Tx, ExtensionOptions } from '@terra-money/feather.js';
 import { NetworkInfo } from './types';
 
-type ConnectResponse = { address?: string };
+type ConnectResponse = { address: string; pubkey: Record<number, string> };
 type InfoResponse = Record<string, NetworkInfo>;
 type SignResponse = {
   payload: {

--- a/wallets/terra-extension/src/extension/signer.ts
+++ b/wallets/terra-extension/src/extension/signer.ts
@@ -1,10 +1,14 @@
 import {
-  OfflineDirectSigner,
   AccountData,
   DirectSignResponse,
   encodePubkey,
 } from '@cosmjs/proto-signing';
-import { StdSignature } from '@cosmjs/amino';
+import {
+  OfflineAminoSigner,
+  AminoSignResponse,
+  StdSignDoc,
+  StdSignature,
+} from '@cosmjs/amino';
 import { WalletAccount } from '@cosmos-kit/core';
 import { TerraExtension } from './extension';
 import {
@@ -12,7 +16,11 @@ import {
   AuthInfo,
   SignerInfo,
 } from 'cosmjs-types/cosmos/tx/v1beta1/tx';
-import { Fee as TerraFee, Msg as TerraMsg } from '@terra-money/feather.js';
+import {
+  Fee as TerraFee,
+  Msg as TerraMsg,
+  SignMode,
+} from '@terra-money/feather.js';
 
 export interface SignDoc {
   bodyBytes: Uint8Array;
@@ -21,12 +29,12 @@ export interface SignDoc {
   accountNumber: Long;
 }
 
-export class OfflineSigner implements OfflineDirectSigner {
-  private client: TerraExtension;
+export class OfflineSigner implements OfflineAminoSigner {
+  private extension: TerraExtension;
   accountInfo: WalletAccount;
 
-  constructor(client: TerraExtension, accountInfo: WalletAccount) {
-    this.client = client;
+  constructor(extension: TerraExtension, accountInfo: WalletAccount) {
+    this.extension = extension;
     this.accountInfo = accountInfo;
   }
 
@@ -40,7 +48,52 @@ export class OfflineSigner implements OfflineDirectSigner {
     ];
   }
 
-  async signDirect(
+  async signAmino(
+    signerAddress: string,
+    signDoc: StdSignDoc
+  ): Promise<AminoSignResponse> {
+    console.log('signAmino', signerAddress, signDoc);
+    const signDocFee = signDoc.fee;
+    const feeAmount = signDocFee.amount[0].amount + signDocFee.amount[0].denom;
+
+    const fakeMsgs = signDoc.msgs.map((msg) =>
+      TerraMsg.fromAmino(msg as TerraMsg.Amino)
+    );
+
+    const signResponse = await this.extension.sign({
+      chainID: signDoc.chain_id,
+      msgs: fakeMsgs as any,
+      // remark
+      // Not sure how to request signMode to station wallet
+      // station keep using SIGN_MODE_DIRECT
+      signMode: SignMode.SIGN_MODE_LEGACY_AMINO_JSON,
+      fee: new TerraFee(
+        parseInt(signDocFee.gas),
+        feeAmount,
+        signDocFee.payer,
+        signDocFee.granter
+      ),
+      memo: signDoc.memo,
+    } as any);
+
+    console.log('signResponse xx', signResponse);
+
+    const signature: StdSignature = {
+      pub_key: (signResponse.payload.result.auth_info.signer_infos[0]
+        .public_key as any).key,
+      signature: signResponse.payload.result.signatures[0],
+    };
+
+    console.log('signature', signature);
+
+    return {
+      signed: signDoc,
+      signature,
+    };
+  }
+
+  // To force `cosmos-kit` use `signAmino` instead of `signDirect`
+  async signDirectKKK(
     _signerAddress: string,
     _signDoc: SignDoc
   ): Promise<DirectSignResponse> {
@@ -59,7 +112,7 @@ export class OfflineSigner implements OfflineDirectSigner {
 
     const chainID = _signDoc.chainId;
 
-    const signResponse = await this.client.sign({
+    const signResponse = await this.extension.sign({
       chainID,
       msgs: txbody.messages.map((msg) => TerraMsg.fromProto(msg)),
       fee,

--- a/yarn.lock
+++ b/yarn.lock
@@ -5341,10 +5341,10 @@
   dependencies:
     tslib "^2.4.0"
 
-"@terra-money/feather.js@^1.0.0-beta.12":
-  version "1.0.0-beta.12"
-  resolved "https://registry.yarnpkg.com/@terra-money/feather.js/-/feather.js-1.0.0-beta.12.tgz#285af7b0fc37551df1d8c15ceae69d87c1bbe23b"
-  integrity sha512-O1Q9pZ9nK/ZbXWtt7xvX2OoyiUCgUeAzHMNiSzzfyCYupRFWDqwuSf3MASyW+KjjST6yhbv4hyM1mThApdgcoA==
+"@terra-money/feather.js@^1.0.0-beta.14":
+  version "1.0.0-beta.15"
+  resolved "https://registry.yarnpkg.com/@terra-money/feather.js/-/feather.js-1.0.0-beta.15.tgz#d81e31f28428cb23a27bf067eaa7e8f399e9c511"
+  integrity sha512-KKmwmLemorifApC7y7Rn8H8MzdPmHnTkpqncfHdvWLzhGxeRw0hv24ZPkOj+SOZbhdutwp2RtAH1IEZz23cHUQ==
   dependencies:
     "@terra-money/legacy.proto" "npm:@terra-money/terra.proto@^0.1.7"
     "@terra-money/terra.proto" "^2.2.0-beta.4"


### PR DESCRIPTION
### Description
The current issue pertains to two problems:

1. The signAmino function in [`SigningCosmWasmStargateClient`](https://github.com/cosmos/cosmjs/blob/main/packages/cosmwasm-stargate/src/signingcosmwasmclient.ts#L568) or `SigningStargateClient` requires a public key to generate an `AuthInfo` object, which is not currently available on Station.

2. The second problem relates to requesting a signing operation from Station while using SignMode as SIGN_MODE_LEGACY_AMINO_JSON. This functionality is not currently working as intended. [link](https://github.com/alleslabs/cosmos-kit/pull/2/files#diff-52733c5197dc5224e281a5ea711fd85ba1d47dcd1d0119780cdc57d46fff2239R67). TLDR is that Station keeps using SIGN_MODE_DIRECT atm. Not sure if it is a misunderstanding on our side or a bug in station 